### PR TITLE
ci: use Node 20.19 in workflow

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: '20.19'
       - run: npm ci
       - run: npm run build
       - uses: actions/deploy-pages@v2


### PR DESCRIPTION
## Summary
- use Node 20.19 in GitHub Pages workflow

## Testing
- `npm ci`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6896228667f8832e92370db758359032