### PR TITLE
Fix GitHub Pages deployment workflow

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -2,6 +2,12 @@ name: Deploy to GitHub Pages
 on:
   push:
     branches: [main]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
 jobs:
   build-deploy:
     runs-on: ubuntu-latest
@@ -12,8 +18,9 @@ jobs:
           node-version: '20.19'
       - run: npm ci
       - run: npm run build
-      - uses: actions/deploy-pages@v2
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+      - uses: actions/deploy-pages@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          branch: gh-pages
-          folder: dist


### PR DESCRIPTION
## Summary
- remove unsupported branch and folder inputs
- upload build artifacts and grant required permissions
- deploy to GitHub Pages using official action

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68962480c498832e9d00f724ded18cce