### PR TITLE
Expand landing page with additional form components

### DIFF
--- a/css/forms.css
+++ b/css/forms.css
@@ -566,3 +566,115 @@
 
 .btn-block {
   width: 100%; }
+
+.required {
+  color: #E01515;
+  margin-left: .25rem; }
+
+.phone-row {
+  display: flex;
+  gap: 1rem; }
+  .phone-row .input-field {
+    flex: 1; }
+  .phone-row .input-field.select {
+    flex: 0 0 30%; }
+
+.toggle-field {
+  display: flex;
+  align-items: center;
+  gap: .5rem;
+  margin: 1rem 0; }
+
+.switch {
+  position: relative;
+  display: inline-block;
+  width: 40px;
+  height: 20px; }
+  .switch input {
+    opacity: 0;
+    width: 0;
+    height: 0; }
+  .switch .slider {
+    position: absolute;
+    cursor: pointer;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-color: #f2f5fa;
+    transition: .4s;
+    border-radius: 20px; }
+    .switch .slider:before {
+      position: absolute;
+      content: "";
+      height: 16px;
+      width: 16px;
+      left: 2px;
+      bottom: 2px;
+      background-color: white;
+      transition: .4s;
+      border-radius: 50%; }
+  .switch input:checked + .slider {
+    background-color: #00319A; }
+    .switch input:checked + .slider:before {
+      transform: translateX(20px); }
+
+.number-field {
+  position: relative; }
+  .number-field .number-controls {
+    position: absolute;
+    right: .2rem;
+    top: 50%;
+    transform: translateY(-50%);
+    display: flex;
+    flex-direction: column; }
+    .number-field .number-controls button {
+      background: transparent;
+      border: none;
+      cursor: pointer;
+      line-height: 1;
+      padding: 0;
+      color: #00319A; }
+
+.tags-field {
+  margin-top: 1rem;
+  margin-bottom: 1rem; }
+  .tags-field label {
+    font-family: 'Montserrat', sans-serif;
+    font-style: normal;
+    font-weight: 600;
+    letter-spacing: .3px;
+    font-size: 12px;
+    color: #00319A;
+    display: block;
+    margin-bottom: .5rem; }
+  .tags-field .tags-input {
+    display: flex;
+    flex-wrap: wrap;
+    gap: .5rem;
+    background-color: #00319A10;
+    border-radius: 0.6rem;
+    padding: .5rem;
+    min-height: 2.8rem; }
+    .tags-field .tags-input .tag {
+      background-color: #00319A;
+      color: #fff;
+      padding: 0 .5rem;
+      border-radius: .3rem;
+      font-family: 'Montserrat', sans-serif;
+      font-style: normal;
+      font-weight: 600;
+      letter-spacing: .3px;
+      font-size: 12px; }
+    .tags-field .tags-input input {
+      font-family: 'Montserrat', sans-serif;
+      font-style: normal;
+      font-weight: 600;
+      letter-spacing: .3px;
+      font-size: 12px;
+      border: none;
+      outline: none;
+      background: transparent;
+      color: #00319A;
+      flex: 1;
+      min-width: 5rem; }

--- a/index.html
+++ b/index.html
@@ -40,32 +40,78 @@
     <form>
       <div class="input-field">
         <input id="lastname" type="text" required>
-        <label for="lastname">Last Name</label>
+        <label for="lastname">Last Name<span class="required">*</span></label>
       </div>
       <div class="input-field">
         <input id="firstname" type="text" required>
-        <label for="firstname">First Name</label>
+        <label for="firstname">First Name<span class="required">*</span></label>
       </div>
       <div class="input-field is-valid">
         <input id="email" type="email" required>
-        <label for="email">Email</label>
+        <label for="email">Email<span class="required">*</span></label>
       </div>
       <div class="input-field is-invalid">
         <input id="password" type="password" required>
-        <label for="password">Password</label>
+        <label for="password">Password<span class="required">*</span></label>
       </div>
       <div class="input-field">
         <input id="confirm" type="password" required>
-        <label for="confirm">Confirm Password</label>
+        <label for="confirm">Confirm Password<span class="required">*</span></label>
       </div>
+
+      <div class="phone-row">
+        <div class="input-field select">
+          <select id="country-code" required>
+            <option value="" disabled selected>Code</option>
+            <option value="+1">+1 US</option>
+            <option value="+44">+44 UK</option>
+            <option value="+52">+52 MX</option>
+          </select>
+          <label class="active">Code<span class="required">*</span></label>
+        </div>
+        <div class="input-field">
+          <input id="phone" type="tel" required>
+          <label for="phone">Phone Number<span class="required">*</span></label>
+        </div>
+      </div>
+
       <div class="input-field select">
         <select required>
           <option value="" disabled selected>Select Option</option>
           <option value="1">Option One</option>
           <option value="2">Option Two</option>
         </select>
-        <label class="active">Options</label>
+        <label class="active">Options<span class="required">*</span></label>
       </div>
+
+      <div class="number-field input-field">
+        <input id="quantity" type="number" min="0" value="0" required>
+        <label for="quantity">Quantity<span class="required">*</span></label>
+        <div class="number-controls">
+          <button type="button" class="decrement">-</button>
+          <button type="button" class="increment">+</button>
+        </div>
+      </div>
+
+      <div class="tags-field">
+        <label for="tags-text">Tags</label>
+        <div class="tags-input" id="tags-input">
+          <input type="text" id="tags-text" placeholder="Type and press Enter">
+        </div>
+      </div>
+
+      <div class="toggle-field">
+        <label class="switch">
+          <input type="checkbox" id="toggle-example">
+          <span class="slider"></span>
+        </label>
+        <span>Enable notifications</span>
+      </div>
+
+      <label>
+        <input type="checkbox" required />
+        <span>I agree to the terms<span class="required">*</span></span>
+      </label>
       <label>
         <input type="checkbox" />
         <span>Subscribe to newsletter</span>

--- a/js/forms.js
+++ b/js/forms.js
@@ -96,5 +96,40 @@ document.addEventListener('DOMContentLoaded', function () {
       }
     });
   });
+
+  // Number input controls
+  document.querySelectorAll('.number-field').forEach(function (wrapper) {
+    const input = wrapper.querySelector('input[type=number]');
+    const inc = wrapper.querySelector('.increment');
+    const dec = wrapper.querySelector('.decrement');
+    if (inc) {
+      inc.addEventListener('click', function () {
+        input.stepUp();
+        input.dispatchEvent(new Event('change'));
+      });
+    }
+    if (dec) {
+      dec.addEventListener('click', function () {
+        input.stepDown();
+        input.dispatchEvent(new Event('change'));
+      });
+    }
+  });
+
+  // Tags input
+  const tagsInput = document.getElementById('tags-text');
+  const tagsContainer = document.getElementById('tags-input');
+  if (tagsInput && tagsContainer) {
+    tagsInput.addEventListener('keydown', function (e) {
+      if (e.key === 'Enter' && tagsInput.value.trim() !== '') {
+        e.preventDefault();
+        const tag = document.createElement('span');
+        tag.className = 'tag';
+        tag.textContent = tagsInput.value.trim();
+        tagsContainer.insertBefore(tag, tagsInput);
+        tagsInput.value = '';
+      }
+    });
+  }
 });
 

--- a/scss/forms.scss
+++ b/scss/forms.scss
@@ -365,3 +365,135 @@ $border-radius: .6rem;
 .btn-block {
   width: 100%;
 }
+
+.required {
+  color: $danger;
+  margin-left: .25rem;
+}
+
+.phone-row {
+  display: flex;
+  gap: 1rem;
+
+  .input-field {
+    flex: 1;
+  }
+
+  .input-field.select {
+    flex: 0 0 30%;
+  }
+}
+
+.toggle-field {
+  display: flex;
+  align-items: center;
+  gap: .5rem;
+  margin: 1rem 0;
+}
+
+.switch {
+  position: relative;
+  display: inline-block;
+  width: 40px;
+  height: 20px;
+
+  input {
+    opacity: 0;
+    width: 0;
+    height: 0;
+  }
+
+  .slider {
+    position: absolute;
+    cursor: pointer;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-color: $secondary;
+    transition: .4s;
+    border-radius: 20px;
+
+    &:before {
+      position: absolute;
+      content: '';
+      height: 16px;
+      width: 16px;
+      left: 2px;
+      bottom: 2px;
+      background-color: white;
+      transition: .4s;
+      border-radius: 50%;
+    }
+  }
+
+  input:checked + .slider {
+    background-color: $primary;
+
+    &:before {
+      transform: translateX(20px);
+    }
+  }
+}
+
+.number-field {
+  position: relative;
+
+  .number-controls {
+    position: absolute;
+    right: .2rem;
+    top: 50%;
+    transform: translateY(-50%);
+    display: flex;
+    flex-direction: column;
+
+    button {
+      background: transparent;
+      border: none;
+      cursor: pointer;
+      line-height: 1;
+      padding: 0;
+      color: $primary;
+    }
+  }
+}
+
+.tags-field {
+  margin-top: 1rem;
+  margin-bottom: 1rem;
+
+  label {
+    @extend .default-font;
+    color: $primary;
+    display: block;
+    margin-bottom: .5rem;
+  }
+
+  .tags-input {
+    display: flex;
+    flex-wrap: wrap;
+    gap: .5rem;
+    background-color: $primary-light;
+    border-radius: $border-radius;
+    padding: .5rem;
+    min-height: 2.8rem;
+
+    .tag {
+      background-color: $primary;
+      color: #fff;
+      padding: 0 .5rem;
+      border-radius: .3rem;
+      @extend .default-font;
+    }
+
+    input {
+      @extend .default-font;
+      border: none;
+      outline: none;
+      background: transparent;
+      color: $primary;
+      flex: 1;
+      min-width: 5rem;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Display required field marker for all mandatory inputs
- Showcase phone input with country code selector and number field with controls
- Add toggle switch and tag entry widget to the demo form

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6896f7fa8f14832e8a247f5a818bad54