### PR TITLE
Add client-side input validation

### DIFF
--- a/dist/latina-forms.js
+++ b/dist/latina-forms.js
@@ -234,5 +234,38 @@ document.addEventListener('DOMContentLoaded', function () {
       }
     });
   }
+
+  // Input validation
+  function updateValidity(el) {
+    const container = el.closest('.input-field');
+    if (!container) return;
+    if (!el.checkValidity()) {
+      container.classList.add('is-invalid');
+      container.classList.remove('is-valid');
+    } else {
+      container.classList.remove('is-invalid');
+      container.classList.add('is-valid');
+    }
+  }
+
+  document.addEventListener(
+    'input',
+    function (e) {
+      if (e.target.matches(inputSelector)) {
+        updateValidity(e.target);
+      }
+    },
+    true
+  );
+
+  document.addEventListener(
+    'blur',
+    function (e) {
+      if (e.target.matches(inputSelector)) {
+        updateValidity(e.target);
+      }
+    },
+    true
+  );
 });
 

--- a/index.html
+++ b/index.html
@@ -49,7 +49,7 @@
         <input id="email" type="email" required>
         <label for="email">Email<span class="required">*</span></label>
       </div>
-      <div class="input-field is-invalid">
+      <div class="input-field">
         <input id="password" type="password" required>
         <label for="password">Password<span class="required">*</span></label>
       </div>

--- a/js/forms.js
+++ b/js/forms.js
@@ -142,5 +142,38 @@ document.addEventListener('DOMContentLoaded', function () {
       }
     });
   }
+
+  // Input validation
+  function updateValidity(el) {
+    const container = el.closest('.input-field');
+    if (!container) return;
+    if (!el.checkValidity()) {
+      container.classList.add('is-invalid');
+      container.classList.remove('is-valid');
+    } else {
+      container.classList.remove('is-invalid');
+      container.classList.add('is-valid');
+    }
+  }
+
+  document.addEventListener(
+    'input',
+    function (e) {
+      if (e.target.matches(inputSelector)) {
+        updateValidity(e.target);
+      }
+    },
+    true
+  );
+
+  document.addEventListener(
+    'blur',
+    function (e) {
+      if (e.target.matches(inputSelector)) {
+        updateValidity(e.target);
+      }
+    },
+    true
+  );
 });
 


### PR DESCRIPTION
## Summary
- Mark inputs as invalid or valid based on HTML5 validation, updating parent classes accordingly
- Remove hard-coded invalid class from the sample password field
- Rebuild distribution bundle

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689721b2b6ac832e9469a4a5021b9da1