### PR TITLE
style: update landing backgrounds and feature colors

### DIFF
--- a/css/landing.css
+++ b/css/landing.css
@@ -3,13 +3,12 @@
 body {
   margin: 0;
   color: #f2f5fa;
-  background: linear-gradient(135deg, #9d4edd, #7b2cbf);
+  background: linear-gradient(205deg, #000000, #7b2cbf);
 }
 
 .hero {
   text-align: center;
   padding: 4rem 1rem;
-  background: linear-gradient(135deg, #9d4edd, #7b2cbf);
   color: #ffffff;
 }
 
@@ -50,10 +49,9 @@ a.btn-primary {
   background: rgba(255, 255, 255, 0.15);
   backdrop-filter: blur(10px);
   -webkit-backdrop-filter: blur(10px);
-  border: 1px solid rgba(255, 255, 255, 0.3);
   border-radius: 0.6rem;
   box-shadow: 0 4px 30px rgba(0, 0, 0, 0.1);
-  color: #7B2CBF;
+  color: #ffffff;
 }
 
 .demo {

--- a/css/styles.css
+++ b/css/styles.css
@@ -1,6 +1,6 @@
 @import url("https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&display=swap");
 body {
-  background: linear-gradient(135deg, #9d4edd, #7b2cbf);
+  background: linear-gradient(205deg, #000000, #7b2cbf);
   color: #f2f5fa;
   font-family: "Montserrat", sans-serif;
 }

--- a/dist/latina-forms.css
+++ b/dist/latina-forms.css
@@ -1,6 +1,6 @@
 @import url("https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&display=swap");
 body {
-  background: linear-gradient(135deg, #9d4edd, #7b2cbf);
+  background: linear-gradient(205deg, #000000, #7b2cbf);
   color: #f2f5fa;
   font-family: "Montserrat", sans-serif;
 }

--- a/scss/styles.scss
+++ b/scss/styles.scss
@@ -6,7 +6,7 @@ $success: #23A318;
 $warning: #E5646E;
 $danger: #FF4B55;
 
-$bg: linear-gradient(135deg, #9d4edd, #7b2cbf);
+$bg: linear-gradient(205deg, #000000, #7b2cbf);
 
 body {
   background: $bg;


### PR DESCRIPTION
## Summary
- remove background from hero header and update feature text color
- switch body background to linear-gradient(205deg, #000000, #7b2cbf)
- sync SCSS and compiled CSS with new gradient

## Testing
- `npm run build`
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_6899f81f65e8832eb053e05c8c28e2c0