### PR TITLE
Style tweaks for footer, tags, and switch

### DIFF
--- a/css/forms.css
+++ b/css/forms.css
@@ -409,7 +409,7 @@
   pointer-events: none;
 }
 [type=checkbox] + span:not(.slider) {
-  color: #5A189A;
+  color: #fff;
   position: relative;
   padding-left: 35px;
   cursor: pointer;
@@ -783,7 +783,7 @@
   width: 20px;
   left: 0;
   top: 0;
-  background-color: white;
+  background-color: #5A189A;
   transition: 0.4s;
   border-radius: 50%;
 }
@@ -869,7 +869,7 @@
   border: none;
   outline: none;
   background: transparent;
-  color: #5A189A;
+  color: #fff;
   flex: 1;
   min-width: 5rem;
 }

--- a/css/landing.css
+++ b/css/landing.css
@@ -94,5 +94,6 @@ a.btn-primary {
   text-align: center;
   padding: 2rem 1rem;
   background: #f2f5fa;
+  color: #7B2CBF;
 }
 

--- a/dist/latina-forms.css
+++ b/dist/latina-forms.css
@@ -415,7 +415,7 @@ body {
   pointer-events: none;
 }
 [type=checkbox] + span:not(.slider) {
-  color: #5A189A;
+  color: #fff;
   position: relative;
   padding-left: 35px;
   cursor: pointer;
@@ -789,7 +789,7 @@ body {
   width: 20px;
   left: 0;
   top: 0;
-  background-color: white;
+  background-color: #5A189A;
   transition: 0.4s;
   border-radius: 50%;
 }
@@ -875,7 +875,7 @@ body {
   border: none;
   outline: none;
   background: transparent;
-  color: #5A189A;
+  color: #fff;
   flex: 1;
   min-width: 5rem;
 }

--- a/index.html
+++ b/index.html
@@ -45,7 +45,7 @@
         <input id="firstname" type="text" required>
         <label for="firstname">First Name<span class="required">*</span></label>
       </div>
-      <div class="input-field is-valid">
+      <div class="input-field">
         <input id="email" type="email" required>
         <label for="email">Email<span class="required">*</span></label>
       </div>

--- a/scss/forms.scss
+++ b/scss/forms.scss
@@ -243,7 +243,7 @@ $border-radius: .6rem;
 
   + span:not(.slider) {
     @extend .default-font;
-    color: $primary-dark;
+    color: #fff;
     position: relative;
     padding-left: 35px;
     cursor: pointer;
@@ -438,7 +438,7 @@ $border-radius: .6rem;
       width: 20px;
       left: 0;
       top: 0;
-      background-color: white;
+      background-color: #5A189A;
       transition: .4s;
       border-radius: 50%;
     }
@@ -538,7 +538,7 @@ $border-radius: .6rem;
       border: none;
       outline: none;
       background: transparent;
-      color: $primary-dark;
+      color: #fff;
       flex: 1;
       min-width: 5rem;
     }


### PR DESCRIPTION
## Summary
- Remove default validation class from email field
- Add Latina violet footer text and adjust checkbox and tag text colors
- Tint switch knob to #5A189A

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689b1e6b0f68832eac184ce8f618066c